### PR TITLE
Ability to screenshot from HTTP History/Sitemap

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,7 +14,7 @@
     "vue": "3.5.13"
   },
   "devDependencies": {
-    "@caido/sdk-frontend": "0.54.1",
+    "@caido/sdk-frontend": "0.55.1",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "6.36.6",
     "@types/lodash-es": "4.17.12",

--- a/packages/frontend/src/stores/overlay.ts
+++ b/packages/frontend/src/stores/overlay.ts
@@ -3,11 +3,13 @@ import { ref, type Ref } from "vue";
 type OverlayState = {
   isOpen: boolean;
   sessionId: string | undefined;
+  requestId: string | undefined;
 };
 
 const overlayState: Ref<OverlayState> = ref({
   isOpen: false,
   sessionId: undefined,
+  requestId: undefined,
 });
 
 export function getOverlayState(): Ref<OverlayState> {
@@ -18,6 +20,15 @@ export function openOverlay(sessionId: string): void {
   overlayState.value = {
     isOpen: true,
     sessionId,
+    requestId: undefined,
+  };
+}
+
+export function openOverlayForRequest(requestId: string): void {
+  overlayState.value = {
+    isOpen: true,
+    sessionId: undefined,
+    requestId,
   };
 }
 
@@ -25,5 +36,6 @@ export function closeOverlay(): void {
   overlayState.value = {
     isOpen: false,
     sessionId: undefined,
+    requestId: undefined,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         version: 3.5.13(typescript@5.8.3)
     devDependencies:
       '@caido/sdk-frontend':
-        specifier: 0.54.1
-        version: 0.54.1(@ai-sdk/provider@2.0.0)(@codemirror/state@6.5.2)(@codemirror/view@6.36.6)(vue@3.5.13(typescript@5.8.3))
+        specifier: 0.55.1
+        version: 0.55.1(@ai-sdk/provider@2.0.0)(@codemirror/state@6.5.2)(@codemirror/view@6.36.6)(vue@3.5.13(typescript@5.8.3))
       '@codemirror/state':
         specifier: ^6.5.2
         version: 6.5.2
@@ -122,10 +122,10 @@ packages:
     peerDependencies:
       primevue: 4.1.0
 
-  '@caido/sdk-frontend@0.54.1':
-    resolution: {integrity: sha512-juLWVTTAb8Klcyafs1t8M4hhD9gNNDsm9XnMMEW3GO96upW/JIZjRZH3IHbD5CL4ihvjL34BznHKHm2P3ZG3aw==}
+  '@caido/sdk-frontend@0.55.1':
+    resolution: {integrity: sha512-AJqpqA+Dlh3jZvYKLyVIb8HQIOT5TJLrDQ1JBr0zhIopptSGqIEZaY2BADYOq667HOwS3Xi/jKuVlboTSjOFnA==}
     peerDependencies:
-      '@ai-sdk/provider': ^2.0.0
+      '@ai-sdk/provider': ^3.0.1
       '@codemirror/state': ^6.0.0
       '@codemirror/view': ^6.0.0
       vue: ^3.0.0
@@ -2698,7 +2698,7 @@ snapshots:
     dependencies:
       primevue: 4.1.0(vue@3.5.13(typescript@5.8.3))
 
-  '@caido/sdk-frontend@0.54.1(@ai-sdk/provider@2.0.0)(@codemirror/state@6.5.2)(@codemirror/view@6.36.6)(vue@3.5.13(typescript@5.8.3))':
+  '@caido/sdk-frontend@0.55.1(@ai-sdk/provider@2.0.0)(@codemirror/state@6.5.2)(@codemirror/view@6.36.6)(vue@3.5.13(typescript@5.8.3))':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@codemirror/state': 6.5.2


### PR DESCRIPTION
This change allows the users to Screenshot requests from HTTP History and Sitemap through CommadPallete/Shortcut, due the SDK limitations we can't screenshot from history, findings, others.
Fixes #18 



### Merge #27 First!